### PR TITLE
Fixed initialization of xml for AppEngine compability

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -25,9 +25,15 @@ func (p *xmlPlistGenerator) generateDocument(pval *plistValue) {
 	io.WriteString(p.writer, xmlDOCTYPE)
 
 	plistStartElement := xml.StartElement{
-		xml.Name{"", "plist"},
-		[]xml.Attr{
-			{xml.Name{"", "version"}, "1.0"},
+		Name: xml.Name{
+			Space: "",
+			Name:  "plist",
+		},
+		Attr: []xml.Attr{
+			Name: xml.Name{
+				Space: "",
+				Name:  "version"},
+			Value: "1.0",
 		},
 	}
 

--- a/xml.go
+++ b/xml.go
@@ -27,13 +27,13 @@ func (p *xmlPlistGenerator) generateDocument(pval *plistValue) {
 	plistStartElement := xml.StartElement{
 		Name: xml.Name{
 			Space: "",
-			Name:  "plist",
+			Local: "plist",
 		},
-		Attr: []xml.Attr{
+		Attr: []xml.Attr{{
 			Name: xml.Name{
 				Space: "",
-				Name:  "version"},
-			Value: "1.0",
+				Local: "version"},
+			Value: "1.0"},
 		},
 	}
 


### PR DESCRIPTION
AppEngine requires structs to use keyed fields when initializing.

(see this comment on another package: http://grokbase.com/p/gg/golang-nuts/143ybgkhc0/go-nuts-unkeyed-fields)