### PR TITLE
Added support for a RawPlistValue which enables defered (un)marshalling of data

### DIFF
--- a/common_data_for_test.go
+++ b/common_data_for_test.go
@@ -112,6 +112,20 @@ var tests = []TestData{
 		},
 	},
 	{
+		Name: "Raw Plist Value",
+		Data: struct {
+			Name RawPlistValue
+		}{
+			Name: RawPlistValue{String, "Dustin"},
+		},
+		Expected: map[int][]byte{
+			OpenStepFormat: []byte(`{Name=Dustin;}`),
+			GNUStepFormat:  []byte(`{Name=Dustin;}`),
+			XMLFormat:      []byte(xmlPreamble + `<plist version="1.0"><dict><key>Name</key><string>Dustin</string></dict></plist>`),
+			BinaryFormat:   []byte{98, 112, 108, 105, 115, 116, 48, 48, 209, 1, 2, 84, 78, 97, 109, 101, 86, 68, 117, 115, 116, 105, 110, 8, 11, 16, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23},
+		},
+	},
+	{
 		Name: "Basic Structure with non-exported fields",
 		Data: struct {
 			Name string

--- a/common_data_for_test.go
+++ b/common_data_for_test.go
@@ -126,6 +126,20 @@ var tests = []TestData{
 		},
 	},
 	{
+		Name: "Raw Plist Value Pointer",
+		Data: struct {
+			Name *RawPlistValue
+		}{
+			Name: &RawPlistValue{String, "Dustin"},
+		},
+		Expected: map[int][]byte{
+			OpenStepFormat: []byte(`{Name=Dustin;}`),
+			GNUStepFormat:  []byte(`{Name=Dustin;}`),
+			XMLFormat:      []byte(xmlPreamble + `<plist version="1.0"><dict><key>Name</key><string>Dustin</string></dict></plist>`),
+			BinaryFormat:   []byte{98, 112, 108, 105, 115, 116, 48, 48, 209, 1, 2, 84, 78, 97, 109, 101, 86, 68, 117, 115, 116, 105, 110, 8, 11, 16, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23},
+		},
+	},
+	{
 		Name: "Basic Structure with non-exported fields",
 		Data: struct {
 			Name string

--- a/decode.go
+++ b/decode.go
@@ -116,3 +116,21 @@ func Unmarshal(data []byte, v interface{}) (format int, err error) {
 	format = dec.Format
 	return
 }
+
+// Decode works like Unmarshal, except it operates on the raw property list value.
+func (data RawPlistValue) Decode(v interface{}) (err error) {
+	dec := Decoder{}
+	pval := plistValue(data)
+
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			err = r.(error)
+		}
+	}()
+
+	dec.unmarshal(&pval, reflect.ValueOf(v))
+	return
+}

--- a/decode.go
+++ b/decode.go
@@ -117,11 +117,8 @@ func Unmarshal(data []byte, v interface{}) (format int, err error) {
 	return
 }
 
-// Decode works like Unmarshal, except it operates on the raw property list value.
-func (data RawPlistValue) Decode(v interface{}) (err error) {
-	dec := Decoder{}
-	pval := plistValue(data)
-
+// DecodeElement works like plist.Unmarshal except that it takes a pointer to the start element to decode into v.
+func (p *Decoder) DecodeElement(v interface{}, start *plistValue) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -131,6 +128,13 @@ func (data RawPlistValue) Decode(v interface{}) (err error) {
 		}
 	}()
 
-	dec.unmarshal(&pval, reflect.ValueOf(v))
+	p.unmarshal(start, reflect.ValueOf(v))
 	return
+}
+
+// Unmarshaler is the interface implemented by objects that can unmarshal a Plist value of themselves.
+//
+// One common implementation strategy is to unmarshal into a separate value with a layout matching the expected XML using p.DecodeElement, and then to copy the data from that value into the receiver.
+type Unmarshaler interface {
+	UnmarshalPlist(p *Decoder, start *plistValue) error
 }

--- a/decode.go
+++ b/decode.go
@@ -118,7 +118,7 @@ func Unmarshal(data []byte, v interface{}) (format int, err error) {
 }
 
 // DecodeElement works like plist.Unmarshal except that it takes a pointer to the start element to decode into v.
-func (p *Decoder) DecodeElement(v interface{}, start *plistValue) (err error) {
+func (p *Decoder) DecodeElement(v interface{}, start *RawPlistValue) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -128,7 +128,7 @@ func (p *Decoder) DecodeElement(v interface{}, start *plistValue) (err error) {
 		}
 	}()
 
-	p.unmarshal(start, reflect.ValueOf(v))
+	p.unmarshal((*plistValue)(start), reflect.ValueOf(v))
 	return
 }
 
@@ -136,5 +136,5 @@ func (p *Decoder) DecodeElement(v interface{}, start *plistValue) (err error) {
 //
 // One common implementation strategy is to unmarshal into a separate value with a layout matching the expected XML using p.DecodeElement, and then to copy the data from that value into the receiver.
 type Unmarshaler interface {
-	UnmarshalPlist(p *Decoder, start *plistValue) error
+	UnmarshalPlist(p *Decoder, start *RawPlistValue) error
 }

--- a/encode.go
+++ b/encode.go
@@ -51,6 +51,24 @@ func (p *Encoder) Encode(v interface{}) (err error) {
 	return
 }
 
+// NewRawPlistValue works like Marshal only it write to a new raw property list value, which can then be reused later with Marshal or Encode
+func NewRawPlistValue(v interface{}) (data RawPlistValue, err error) {
+	enc := Encoder{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			err = r.(error)
+		}
+	}()
+
+	pval := enc.marshal(reflect.ValueOf(v))
+	data = RawPlistValue(*pval)
+	return
+}
+
 // Indent turns on pretty-printing for the XML and Text property list formats.
 // Each element begins on a new line and is preceded by one or more copies of indent according to its nesting depth.
 func (p *Encoder) Indent(indent string) {

--- a/encode.go
+++ b/encode.go
@@ -126,7 +126,7 @@ func MarshalIndent(v interface{}, format int, indent string) ([]byte, error) {
 }
 
 // EncodeElement writes the Plist encoding of v to the stream, using start as the outermost element in the encoding.
-func (p *Encoder) EncodeElement(v interface{}, start *plistValue) (err error) {
+func (p *Encoder) EncodeElement(v interface{}, start *RawPlistValue) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -136,7 +136,7 @@ func (p *Encoder) EncodeElement(v interface{}, start *plistValue) (err error) {
 		}
 	}()
 
-	*start = *p.marshal(reflect.ValueOf(v))
+	*start = RawPlistValue(*p.marshal(reflect.ValueOf(v)))
 	return
 }
 
@@ -144,5 +144,5 @@ func (p *Encoder) EncodeElement(v interface{}, start *plistValue) (err error) {
 //
 // One common implementation strategy is to construct a separate value with a layout corresponding to the desired Plist and then to encode it using p.EncodeElement.
 type Marshaler interface {
-	MarshalPlist(p *Encoder, start *plistValue) error
+	MarshalPlist(p *Encoder, start *RawPlistValue) error
 }

--- a/marshal.go
+++ b/marshal.go
@@ -91,6 +91,14 @@ func (p *Encoder) marshal(val reflect.Value) *plistValue {
 		val = val.Elem()
 	}
 
+	if val.Kind() == reflect.Struct && val.Type() == reflect.TypeOf(RawPlistValue{}) {
+		raw, ok := val.Interface().(RawPlistValue)
+		if ok {
+			pval := plistValue(raw)
+			return &pval
+		}
+	}
+
 	// We got this far and still may have an invalid anything or nil ptr/interface
 	if !val.IsValid() || ((val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface) && val.IsNil()) {
 		return nil

--- a/marshal.go
+++ b/marshal.go
@@ -62,7 +62,7 @@ func (p *Encoder) marshalTime(val reflect.Value) *plistValue {
 
 func (p *Encoder) marshalMarshalerInterface(val reflect.Value) *plistValue {
 	var pval plistValue
-	val.Interface().(Marshaler).MarshalPlist(p, &pval)
+	val.Interface().(Marshaler).MarshalPlist(p, (*RawPlistValue)(&pval))
 	return &pval
 }
 

--- a/plist.go
+++ b/plist.go
@@ -53,6 +53,8 @@ var plistKindNames map[plistKind]string = map[plistKind]string{
 	Date:       "date",
 }
 
+type RawPlistValue plistValue
+
 type plistValue struct {
 	kind  plistKind
 	value interface{}

--- a/plist.go
+++ b/plist.go
@@ -53,8 +53,6 @@ var plistKindNames map[plistKind]string = map[plistKind]string{
 	Date:       "date",
 }
 
-type RawPlistValue plistValue
-
 type plistValue struct {
 	kind  plistKind
 	value interface{}

--- a/raw.go
+++ b/raw.go
@@ -1,14 +1,16 @@
 package plist
 
-// RawPlistValue is a raw encoded Plist object. It implements Marshaler and Unmarshaler and can be used to delay Plist decoding or precompute a Plist encoding.
+// RawPlistValue is a raw encoded Plist object. It implements Marshaler and
+// Unmarshaler and can be used to delay Plist decoding or precompute a Plist
+// encoding using DecodeElement or EncodeElement respectively.
 type RawPlistValue plistValue
 
-func (r *RawPlistValue) UnmarshalPlist(p *Decoder, start *plistValue) error {
-	*r = RawPlistValue(*start)
+func (r *RawPlistValue) UnmarshalPlist(p *Decoder, start *RawPlistValue) error {
+	*r = *start
 	return nil
 }
 
-func (r RawPlistValue) MarshalPlist(p *Encoder, start *plistValue) error {
-	*start = plistValue(r)
+func (r RawPlistValue) MarshalPlist(p *Encoder, start *RawPlistValue) error {
+	*start = r
 	return nil
 }

--- a/raw.go
+++ b/raw.go
@@ -1,0 +1,14 @@
+package plist
+
+// RawPlistValue is a raw encoded Plist object. It implements Marshaler and Unmarshaler and can be used to delay Plist decoding or precompute a Plist encoding.
+type RawPlistValue plistValue
+
+func (r *RawPlistValue) UnmarshalPlist(p *Decoder, start *plistValue) error {
+	*r = RawPlistValue(*start)
+	return nil
+}
+
+func (r RawPlistValue) MarshalPlist(p *Encoder, start *plistValue) error {
+	*start = plistValue(r)
+	return nil
+}

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,0 +1,54 @@
+package plist
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func ExampleRawPlistValue_UnmarshalPlist() {
+	type pbxprojFile struct {
+		RootObjectRef string                    `plist:"rootObject"`
+		Objects       map[string]*RawPlistValue `plist:"objects"`
+	}
+
+	type rootObject struct {
+		IsA                       string `plist:"isa"`
+		BuildConfigurationListRef string `plist:"buildConfigurationList"`
+		CompatibilityVersion      string `plist:"compatibilityVersion"`
+		Attributes                struct {
+			LastUpgradeCheck int
+		} `plist:"attributes"`
+	}
+
+	buf := bytes.NewReader([]byte(`// !$*UTF8*$!
+{
+  objects = {
+    D015A98C1A9E25AC00A8721B /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 0610;
+      };
+      buildConfigurationList = D015A98F1A9E25AC00A8721B /* Build configuration list for PBXProject "Test" */;
+      compatibilityVersion = "Xcode 3.2";
+    };
+  };
+  rootObject = D015A98C1A9E25AC00A8721B /* Project object */;
+}
+`))
+
+	var pbxproj pbxprojFile
+	decoder := NewDecoder(buf)
+	err := decoder.Decode(&pbxproj)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var project rootObject
+	err = decoder.DecodeElement(&project, pbxproj.Objects[pbxproj.RootObjectRef])
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(project)
+
+	// Output: {PBXProject D015A98F1A9E25AC00A8721B Xcode 3.2 {610}}
+}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -69,6 +69,10 @@ func (p *Decoder) unmarshalLaxString(s string, val reflect.Value) {
 	}
 }
 
+func (p *Decoder) unmarshalUnmarshalerInterface(val reflect.Value, pval *plistValue) {
+	val.Interface().(Unmarshaler).UnmarshalPlist(p, (*RawPlistValue)(pval))
+}
+
 func (p *Decoder) unmarshal(pval *plistValue, val reflect.Value) {
 	if pval == nil {
 		return
@@ -82,13 +86,13 @@ func (p *Decoder) unmarshal(pval *plistValue, val reflect.Value) {
 	}
 
 	if val.CanInterface() && val.Type().Implements(selfUnmarshalerType) {
-		val.Interface().(Unmarshaler).UnmarshalPlist(p, pval)
+		p.unmarshalUnmarshalerInterface(val, pval)
 		return
 	}
 	if val.CanAddr() {
 		pv := val.Addr()
 		if pv.CanInterface() && pv.Type().Implements(selfUnmarshalerType) {
-			pv.Interface().(Unmarshaler).UnmarshalPlist(p, pval)
+			p.unmarshalUnmarshalerInterface(pv, pval)
 			return
 		}
 	}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -80,6 +80,11 @@ func (p *Decoder) unmarshal(pval *plistValue, val reflect.Value) {
 		val = val.Elem()
 	}
 
+	if val.Type() == reflect.TypeOf(RawPlistValue{}) {
+		val.Set(reflect.ValueOf(RawPlistValue(*pval)))
+		return
+	}
+
 	if isEmptyInterface(val) {
 		v := p.valueInterface(pval)
 		val.Set(reflect.ValueOf(v))


### PR DESCRIPTION
This is supposed to play the same role as http://golang.org/pkg/encoding/json/#RawMessage though the implementation is different.
