### PR TITLE
Convert XML structure initializers to use keys.

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -25,9 +25,9 @@ func (p *xmlPlistGenerator) generateDocument(pval *plistValue) {
 	io.WriteString(p.writer, xmlDOCTYPE)
 
 	plistStartElement := xml.StartElement{
-		xml.Name{"", "plist"},
-		[]xml.Attr{
-			{xml.Name{"", "version"}, "1.0"},
+		Name: xml.Name{Space: "", Local: "plist"},
+		Attr: []xml.Attr{
+			{Name: xml.Name{Space: "", Local: "version"}, Value: "1.0"},
 		},
 	}
 


### PR DESCRIPTION
The unkeyed initializing was causing compilation failures on Google App Engine.
Quoting a golang-nuts forum post by David Symonds of the App Engine team:

"App Engine has been rejecting app code using unkeyed
composite struct literals since early 2012. The issue is that App
Engine wants to accept correct Go code at time T, but then still be
able to recompile it at time T+n, even if the language or standard
libraries have evolved in a backward-compatible way between those two
points in time. For that reason, it is in general strongly recommended
to use keyed composite struct literals in Go code that references
types in other packages, and we enforce that recommendation on App
Engine."