### PR TITLE
Support parsing XMLs with integers in bases different than 10

### DIFF
--- a/common_data_for_test.go
+++ b/common_data_for_test.go
@@ -13,6 +13,7 @@ type TestData struct {
 	Expected   map[int][]byte
 	ShouldFail bool
 	SkipDecode map[int]bool
+	SkipEncode map[int]bool
 }
 
 type SparseBundleHeader struct {
@@ -258,6 +259,31 @@ var tests = []TestData{
 			XMLFormat:      []byte(xmlPreamble + `<plist version="1.0"><array><integer>255</integer><integer>4095</integer><integer>65535</integer><integer>1048575</integer><integer>16777215</integer><integer>268435455</integer><integer>4294967295</integer><integer>18446744073709551615</integer></array></plist>`),
 			BinaryFormat:   []byte{98, 112, 108, 105, 115, 116, 48, 48, 168, 1, 2, 3, 4, 5, 6, 7, 8, 16, 255, 17, 15, 255, 17, 255, 255, 18, 0, 15, 255, 255, 18, 0, 255, 255, 255, 18, 15, 255, 255, 255, 18, 255, 255, 255, 255, 19, 255, 255, 255, 255, 255, 255, 255, 255, 8, 17, 19, 22, 25, 30, 35, 40, 45, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 54},
 		},
+	},
+	{
+		Name: "Hexadecimal Integers",
+		Data: []int{'h', 'e', 'x', 'i', 'n', 't', -42},
+		Expected: map[int][]byte{
+			XMLFormat: []byte(xmlPreamble + `<plist version="1.0"><array><integer>0x68</integer><integer>0X65</integer><integer>0x78</integer><integer>0X69</integer><integer>0x6e</integer><integer>0X74</integer><integer>-0x2a</integer></array></plist>`),
+		},
+		SkipEncode: map[int]bool{XMLFormat: true},
+	},
+	{
+		Name: "Octal Integers (treated as Decimal)",
+		Data: []int{'o', 'c', 't', 'i', 'n', 't', -42},
+		Expected: map[int][]byte{
+			XMLFormat: []byte(xmlPreamble + `<plist version="1.0"><array><integer>0111</integer><integer>099</integer><integer>0116</integer><integer>0105</integer><integer>0110</integer><integer>0116</integer><integer>-042</integer></array></plist>`),
+		},
+		SkipEncode: map[int]bool{XMLFormat: true},
+	},
+	{
+		Name: "Partial hexadecimal Integer",
+		Data: []int{},
+		Expected: map[int][]byte{
+			XMLFormat: []byte(xmlPreamble + `<plist version="1.0"><integer>0x</integer></plist>`),
+		},
+		ShouldFail: true,
+		SkipEncode: map[int]bool{XMLFormat: true},
 	},
 	{
 		Name: "Floats of Increasing Bitness",

--- a/decode_test.go
+++ b/decode_test.go
@@ -159,6 +159,11 @@ func TestDecode(t *testing.T) {
 		}
 
 		if failed {
+			if test.ShouldFail {
+				t.Logf("Expected: Error")
+				return
+			}
+
 			t.Logf("Expected: %#v\n", d)
 
 			for fmt, dat := range results {

--- a/encode_test.go
+++ b/encode_test.go
@@ -39,6 +39,10 @@ func TestEncode(t *testing.T) {
 
 		results := make(map[int][]byte)
 		for fmt, dat := range test.Expected {
+			if test.SkipEncode[fmt] {
+				continue
+			}
+
 			results[fmt], errors[fmt] = Marshal(test.Data, fmt)
 			failed = failed || (test.ShouldFail && errors[fmt] == nil)
 			failed = failed || !bytes.Equal(dat, results[fmt])

--- a/util.go
+++ b/util.go
@@ -16,3 +16,10 @@ func (w *countedWriter) Write(p []byte) (int, error) {
 func (w *countedWriter) BytesWritten() int {
 	return w.nbytes
 }
+
+func unsignedGetBase(s string) (string, int) {
+	if len(s) > 1 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
+		return s[2:], 16
+	}
+	return s, 10
+}

--- a/xml.go
+++ b/xml.go
@@ -203,10 +203,12 @@ func (p *xmlPlistParser) parseXMLElement(element xml.StartElement) *plistValue {
 		}
 
 		if s[0] == '-' {
-			n := mustParseInt(string(charData), 10, 64)
+			s, base := unsignedGetBase(s[1:])
+			n := mustParseInt("-"+s, base, 64)
 			return &plistValue{Integer, signedInt{uint64(n), true}}
 		} else {
-			n := mustParseUint(string(charData), 10, 64)
+			s, base := unsignedGetBase(s)
+			n := mustParseUint(s, base, 64)
 			return &plistValue{Integer, signedInt{n, false}}
 		}
 	case "real":


### PR DESCRIPTION
Some folks over at NetBSD like their XMLs with hex encoded integers. Since strconv parsers can derive base on their own, I think it will be best to let them do it.