### PR TITLE
Fix go.mod to make module importable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module howett.net/plist
+module github.com/DHowett/go-plist
 
 require (
 	// for cmd/ply


### PR DESCRIPTION
Currently, module is not importable:

```
$ go mod download
go: github.com/DHowett/go-plist@v0.0.0-20181124034731-591f970eefbb: parsing go.mod: unexpected module path "howett.net/plist"
```

This commit should fix this.

Regards,