### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module howett.net/plist
+module github.com/DHowett/go-plist
 
 require (
 	// for cmd/ply


### PR DESCRIPTION
This is required to allow to use go-plist as a module.
A tagged release would be also appreciated.