### PR TITLE
text: add ' to the runes to be quoted when using OpenStep format

### DIFF
--- a/common_data_for_test.go
+++ b/common_data_for_test.go
@@ -160,6 +160,16 @@ var tests = []TestData{
 		},
 	},
 	{
+		Name:  "String containing aposthrope",
+		Value: "'",
+		Documents: map[int][]byte{
+			OpenStepFormat: []byte(`"'"`),
+			GNUStepFormat:  []byte(`"'"`),
+			XMLFormat:      []byte(xmlPreamble + `<plist version="1.0"><string>&#39;</string></plist>`),
+			BinaryFormat:   []byte{98, 112, 108, 105, 115, 116, 48, 48, 81, 39, 8, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10},
+		},
+	},
+	{
 		Name: "Basic Structure",
 		Value: struct {
 			Name string

--- a/common_data_for_test.go
+++ b/common_data_for_test.go
@@ -160,7 +160,7 @@ var tests = []TestData{
 		},
 	},
 	{
-		Name:  "String containing aposthrope",
+		Name:  "String containing apostrophe",
 		Value: "'",
 		Documents: map[int][]byte{
 			OpenStepFormat: []byte(`"'"`),

--- a/text_tables.go
+++ b/text_tables.go
@@ -29,8 +29,9 @@ var gsQuotable = characterSet{
 }
 
 // 7f instead of 3f in the top line: CFOldStylePlist.c says . is valid, but they quote it.
+// ef instead og 6f in the top line: ' will be quoted
 var osQuotable = characterSet{
-	0xf4007f6fffffffff,
+	0xf4007fefffffffff,
 	0xf8000001f8000001,
 	0xffffffffffffffff,
 	0xffffffffffffffff,


### PR DESCRIPTION
Received a "error parsing text property list: missing ; in dictionary .." error when opening an Xcode project saved encoded by the package.
Found the roor cause to be a dictionary value containing an aposthrope, e.g. "JSON's".
Added this character to the bitmap containing quotable chars.﻿
