### PR TITLE
Prevent run time error with padding

### DIFF
--- a/text_generator.go
+++ b/text_generator.go
@@ -21,7 +21,7 @@ type textPlistGenerator struct {
 
 var (
 	textPlistTimeLayout = "2006-01-02 15:04:05 -0700"
-	padding             = "0000"
+	padding             = "00000"
 )
 
 func (p *textPlistGenerator) generateDocument(pval cfValue) {


### PR DESCRIPTION
In some cases this code throws an out of bounds error when trying to add padding.

Error: 

`panic: runtime error: slice bounds out of range [5:4]`
