### PR TITLE
Marshaler support for interface field types.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -31,14 +31,19 @@ var (
 )
 
 func implementsInterface(val reflect.Value, interfaceType reflect.Type) (interface{}, bool) {
-	if val.CanInterface() && val.Type().Implements(interfaceType) {
-		return val.Interface(), true
+	if val.CanInterface() {
+		itf := val.Interface()
+		if itf != nil && reflect.TypeOf(itf).Implements(interfaceType) {
+			return itf, true
+		}
 	}
 
 	if val.CanAddr() {
-		pv := val.Addr()
-		if pv.CanInterface() && pv.Type().Implements(interfaceType) {
-			return pv.Interface(), true
+		if pv := val.Addr(); pv.CanInterface() {
+			itf := pv.Interface()
+			if itf != nil && reflect.TypeOf(itf).Implements(interfaceType) {
+				return itf, true
+			}
 		}
 	}
 	return nil, false

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -71,3 +71,35 @@ func TestInvalidMarshal(t *testing.T) {
 		})
 	}
 }
+
+type Cat struct{}
+
+func (c *Cat) MarshalPlist() (interface{}, error) {
+	return "cat", nil
+}
+
+func TestInterfaceMarshal(t *testing.T) {
+	var c Cat
+	b, err := Marshal(&c, XMLFormat)
+	if err != nil {
+		t.Log(err)
+	} else if len(b) == 0 {
+		t.Log("expect non-zero data")
+	}
+}
+
+func TestInterfaceFieldMarshal(t *testing.T) {
+	type X struct {
+		C interface{} // C's type does not implement Marshaler
+	}
+	x := &X{
+		C: &Cat{}, // C's value implements Marshaler
+	}
+
+	b, err := Marshal(x, XMLFormat)
+	if err != nil {
+		t.Log(err)
+	} else if len(b) == 0 {
+		t.Log("expect non-zero data")
+	}
+}


### PR DESCRIPTION
Expand interface checks beyond the immediate value type. This allows values that implement the `Marshaler` interface but are validly assigned to fields with non-implementing types, such as `interface{}`.

See [`TestInterfaceFieldMarshal`](https://github.com/DHowett/go-plist/pull/72/files#diff-86b8b79c186e030c418e5b4843749915abbd25a8b34108a9982aa48811046cbfR91) for an example of this behaviour.