### PR TITLE
Address panic in parseGNUStepValue

### DIFF
--- a/text_parser.go
+++ b/text_parser.go
@@ -446,6 +446,9 @@ func (p *textPlistParser) parseGNUStepValue() cfValue {
 
 	switch typ {
 	case 'I':
+		if len(v) == 0 {
+			p.error("truncated GNUStep extended value")
+		}
 		if v[0] == '-' {
 			n := mustParseInt(v, 10, 64)
 			return &cfNumber{signed: true, value: uint64(n)}
@@ -457,6 +460,9 @@ func (p *textPlistParser) parseGNUStepValue() cfValue {
 		n := mustParseFloat(v, 64)
 		return &cfReal{wide: true, value: n} // TODO(DH) 32/64
 	case 'B':
+		if len(v) == 0 {
+			p.error("truncated GNUStep extended value")
+		}
 		b := v[0] == 'Y'
 		return cfBoolean(b)
 	case 'D':


### PR DESCRIPTION
This PR addresses a `index out of range` panic in `parseGNUStepValue`. This panic was identified as part of internal fuzzer based testing of our code.


Reproducer
```go
package main

import (
	"bytes"

	"howett.net/plist"
)

func main() {
	data := []byte(`(plist versionGetValue<*B"">`)

	dec := plist.NewDecoder(bytes.NewReader(data))
	res := make(map[string]interface{})

	_ = dec.Decode(res)
}
```


Results

```shell
go run ./main.go

panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
howett.net/plist.(*Decoder).Decode.func1()
	/Users/me/git/go-plist/decode.go:30 +0xac
panic({0x1023deaa0?, 0x14000116018?})
	/usr/local/go/src/runtime/panic.go:914 +0x218
howett.net/plist.(*textPlistParser).parseDocument.func1()
	/Users/me/git/go-plist/text_parser.go:74 +0xe0
panic({0x1023deaa0?, 0x14000116018?})
	/usr/local/go/src/runtime/panic.go:914 +0x218
howett.net/plist.(*textPlistParser).parseGNUStepValue(0x1400010aea0)
	/Users/me/git/go-plist/text_parser.go:460 +0x4e0
howett.net/plist.(*textPlistParser).parsePlistValue(0x1400010aea0)
	/Users/me/git/go-plist/text_parser.go:554 +0x17c
howett.net/plist.(*textPlistParser).parseArray(0x1400010aea0)
	/Users/me/git/go-plist/text_parser.go:399 +0xd4
howett.net/plist.(*textPlistParser).parsePlistValue(0x1400010aea0)
	/Users/me/git/go-plist/text_parser.go:567 +0x190
howett.net/plist.(*textPlistParser).parseDocument(0x1400010aea0)
	/Users/me/git/go-plist/text_parser.go:91 +0xa4
howett.net/plist.(*Decoder).Decode(0x14000140000, {0x1023d21e0, 0x140001101b0})
	/Users/me/git/go-plist/decode.go:58 +0x210
main.main()
	/Users/me/git/go-plist/cmd/crasher/main.go:15 +0xfc
exit status 2
```

I built a quick Fuzzer for `Decode` with a good test corpus in order to identify related bugs but nothing shook out in roughly an hour. 